### PR TITLE
Modernize sanctions UI with toggle switches

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,16 @@
   <title>Sanctions Bustr</title>
   <style>
     :root {
-      --primary: #087DBA;
-      --primary-light: #eaf6ff;
-      --primary-border: #087DBA75;
+      --primary: #4a90e2;
+      --primary-light: #eef4ff;
+      --primary-border: #b6d4fe;
+      --bg: #f8f9fa;
+      --text: #212529;
     }
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #f4faff;
+      background: var(--bg);
+      color: var(--text);
       padding: 2rem;
       text-align: center;
     }
@@ -26,15 +29,31 @@
       width: 100%;
       border:1px solid var(--primary-border);
     }
-    label { display:block; margin-top:1rem; font-weight:bold; color: var(--primary); }
+    label { display:block; margin-top:1rem; font-weight:bold; color: var(--text); }
     input,select{ padding:0.5rem; margin-top:0.5rem; border-radius:5px; border:1px solid #ccc; }
     input:focus,select:focus{ outline:none; border-color:var(--primary); box-shadow:0 0 0 2px var(--primary-border); }
     input[type="date"]{ width:auto; }
     .checkbox-group{ display:flex; flex-direction:column; gap:0.5rem; margin-top:0.5rem; }
-    .checkbox-group label{ font-weight:normal; color:inherit; }
+    .checkbox-group label{ font-weight:normal; color:var(--text); display:flex; align-items:center; gap:0.5rem; }
+    .checkbox-group input[type="checkbox"]{
+      appearance:none;
+      width:40px;
+      height:20px;
+      background:#ccc;
+      border-radius:10px;
+      position:relative;
+      cursor:pointer;
+      transition:background 0.3s;
+    }
+    .checkbox-group input[type="checkbox"]::before{
+      content:"";position:absolute;width:18px;height:18px;background:white;border-radius:50%;top:1px;left:1px;transition:transform 0.3s;
+    }
+    .checkbox-group input[type="checkbox"]:checked{ background:var(--primary); }
+    .checkbox-group input[type="checkbox"]:checked::before{ transform:translateX(20px); }
+    .checkbox-group input[type="checkbox"]:checked + .toggle-label{ color:var(--primary); font-weight:bold; }
     .type-date,.today-btn{ margin-left:0.5rem; }
-    button{ margin-top:1rem; padding:0.75rem 1.5rem; background:var(--primary); color:white; border:none; border-radius:5px; cursor:pointer; transition:background 0.3s; }
-    button:hover{ background:#066a94; }
+    button{ margin-top:1rem; padding:0.75rem 1.5rem; background:var(--primary); color:white; border:none; border-radius:8px; cursor:pointer; transition:background 0.3s; }
+    button:hover{ background:#347dcf; }
     #output{ margin-top:2rem; white-space:pre-wrap; background:#fff; padding:1rem; border-radius:10px; border:1px solid var(--primary-border); text-align:left; }
     .tag-container{ display:flex; flex-wrap:wrap; gap:0.5rem; margin-top:0.5rem; }
     .tag{ background:var(--primary); color:white; padding:0.3rem 0.6rem; border-radius:3px; display:flex; align-items:center; }
@@ -42,17 +61,15 @@
     .instructions {
       margin-top:2rem;
       margin-bottom:1rem;
-      background: var(--primary-light);
+      background:#fff;
       padding:1rem;
       border-radius:8px;
-      border:1px solid var(--primary-border);
-      color: var(--primary);
+      border:1px solid #ddd;
+      color: var(--text);
       text-align:left;
       display:none;
     }
-    .instructions.show {
-      display:block;
-    }
+    .instructions.show { display:block; }
   </style>
     <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAB0lJREFUaEPtWEtPW1cQnjk2kIfANo88CFV42k4EAWOqRt10E0Wq1Ky667LqH6nUn9Btl911WymRuk4ihTdpsXkktEqTkgKxTaFN4Z6pvjnXcAnE1zZEVSS8AMk+95z5Zr75vjmX6T3/8HseP50C+L8reFqB0wocMwPvhEIvxj76Nlbc/urc4twZxLfVN7RT6Gj+5srD+18fM95Dj58YgEJ6VJiZmESIiC2RxOcnDU4spUctvjRk2JIQsUjM/+24gI4NoHgtK0wkLJBkjZ1EhMSQjc1PRhyAMSHyhAFAhNg4lCRMsdyEgqz3UzeAYsplHGGziwbh4zsGAEtk4zkHoJgetUxY7H8cTgfXClkmG8+7tbV+6gJQupYVBKlscDtYMAQBeSK2NT91KBgs3fSpxOCQEKCSeCRsWKkVz0/WHE/NDxRSWWGjJLfEYkR5T9IyXxsVSulRLRkZIrGC0mlZ4rmJmmKqaXExndW0I4PuH9Ff5xsLnRMPErWWHutfDma9pl0yoCCaSLSOtYGoGkAhnRUkSxzLSchILPfoyAYspMYEmY3Pj+v+pTQoR14sPxE9CmgxOaoSoMxyJZV4zilY2KcqAON37pxLLj7f0tYUQ4aEmo/ga+naGNKo9IYKxX+Z8FVor3IaZXNu/FBwAGmtJdbdheIL1fVDVQCK0Hhf9pCpf1l22+cnG8rZ2eq9ses1NURQIKUWUsiQUQcAz4PvEWby3AL6pyny8sLMo4vlPdbTw17URg2aS4QVRGJhKjS+0AVKgVQWe4L5MCQTy+832nb/oLcTbUTmwDDlMRsmy0LxebcOqqXscKKrTY8yvY7yZsfP4y1lEIV0Rti6gzwiac1PhdIoFEAhlbHorIg2GVPLwkGVQOkRjraGy700v8VlS6mMczG4nkWWiYLJAJAC+kE9zoFoDwERCgAN5o4yoD+cc+8ZBI/MWhc7DGknPj/RWKnxiumMpzUqs42EYvl9qsAgRUAj7MfUFkKjUACFZAbJUHkTZokHrF8BOBlHxjieq67xiumsVeE3qIRQS0AQNtBv4KEFDENti5VpVBHA2vWsNHhaUTWZYLk1CCTeObLE8geNDJ4BuTWqS4Zb8k5Sy5/NVFY8QmNb2iUjCT8x6JNCchQIINVUajnzY/f4/c/eVtWKANbTGRtBGDq0CCUCpX7la7cOckQcC2Sx6Nx6T9T9w6UlUL0C+qFsiEQHZPNVasRagSsoc3fb89N7ivcmkFAKhRnJUb8HVMuh0648SJV69j3qmXcCoJgcs2wgpOzid7oiLfnq3LUWcJV7IJWx6DOjxnSQQmr//lzPljgWcE4MfE5m0AUavP4N0qyQzIoYzINQYZbEwn6zbiQzahp40DJ7HQv7plkThTZ7Bu1OtAEjs1prYnFfZaAWarM6hckBAPi6CFMSjAUOQDB4fANPUMdVBIbjAX/ZcE0MgaLS2YZ/e2cfNdXVxHhoYyCjlxEIvTUirbn9TOnQplcxl69YlQMYbnHkoUBaJSqeMxNXp8c/1PP6YZxQUSit4falKePffY7EENoDG/0jmM38IJkTi/umAyXRwcCnOYtnYwvTFW9WcHZWavnyLETxwJ7rA1AnIvEAgKhjeaZijKEA1gdGRHsABxojrW80YhFcxomYWjDgEB/yhHLq9OKPgRan6mTEtNzdMZC9d2+pvAbn+daCMlDHk9njAfjp9u3vMsurX2JAA19wGQtWodg7LNQQ1UsldMd1CzJsbcK/WsIzdMzUG5yzbdHJWSQRmHXWB0as9ZADq1PjxZDgATq0Ali01jeiNz6VlAjT68ZI6fLj8Vg5a5u9Q57XEDVQE9Y/TGLEtubc3biQdLRRgFoj5b9NBOi2cvOT78+vFb7QYVvHCOFLJwXg4a1bN/tW1h+Ur+IA0xbgbRnIRgqTpI4P5GEQ8915HQCQcV9UWxenDyXuz35Qxyp6j4WmBjp7Pr17dyXME6qqADZZ7R/WtGEYdnOzofaArAYPWksOWwx/7blpnefXkxmdiNoWZ46c79f6hjGpQ/R1/IDadS7Pht4FqqZQObhV8F0bEK+o9L2IUqFjcaaudzq/jn78w/nC9ucoj07XCJ6ZLldBnXJMVVeg/MAfvcPuwsd4EYQ/KrHUsVRZ7t6kwktU1PFdr5n+tEGdT+dqiqmmxeUgnvcMYsCQCNTGYXDvqVRhxF5Ymj2yIhvduH5GHDU8vCIAFZ18eSzcVWPwNVMomMXfewc1g9BFFSjM/v7wBj7DTC8tOyCrfcPupg7KWb00u/en6htCnmHb9WSuLhrWVYEgkGc9QzoNYeJzIoOSEO6z1LXsTOhF7w33VkP9Sw1MLHksYujK07mKo8KJqVDYRs+6h7QPjWFhj8iLCH3w5LHS5XnPENxBzUsLYYS6nj4+dvKORaG3AUJ+80PZv89ubkevrszrm7jfeq7vvGqNbQ1PPIiHJaLW308kC7UeepLrTwGcZDbr2eu0AvVk7SSfOa3ASWaznr3+A+o4yV5cbCqhAAAAAElFTkSuQmCC" />
 </head>
@@ -132,10 +149,26 @@
 
     <label>Sanction Types (each can have its own date)</label>
     <div class="checkbox-group">
-      <label class="type-label"><input type="checkbox" name="type" value="UK Entity" onchange="toggleDateInput(this)"> UK Entity <input type="date" id="date-UK Entity" class="type-date" style="display:none;"></label>
-      <label class="type-label"><input type="checkbox" name="type" value="UK Ship" onchange="toggleDateInput(this)"> UK Ship <input type="date" id="date-UK Ship" class="type-date" style="display:none;"></label>
-      <label class="type-label"><input type="checkbox" name="type" value="UNSC" onchange="toggleDateInput(this)"> UNSC <input type="date" id="date-UNSC" class="type-date" style="display:none;"></label>
-      <label class="type-label"><input type="checkbox" name="type" value="UK Director" onchange="toggleDateInput(this)"> UK Director <input type="date" id="date-UK Director" class="type-date" style="display:none;"></label>
+      <label class="type-label">
+        <input type="checkbox" name="type" value="UK Entity" onchange="toggleDateInput(this)">
+        <span class="toggle-label">UK Entity</span>
+        <input type="date" id="date-UK Entity" class="type-date" style="display:none;">
+      </label>
+      <label class="type-label">
+        <input type="checkbox" name="type" value="UK Ship" onchange="toggleDateInput(this)">
+        <span class="toggle-label">UK Ship</span>
+        <input type="date" id="date-UK Ship" class="type-date" style="display:none;">
+      </label>
+      <label class="type-label">
+        <input type="checkbox" name="type" value="UNSC" onchange="toggleDateInput(this)">
+        <span class="toggle-label">UNSC</span>
+        <input type="date" id="date-UNSC" class="type-date" style="display:none;">
+      </label>
+      <label class="type-label">
+        <input type="checkbox" name="type" value="UK Director" onchange="toggleDateInput(this)">
+        <span class="toggle-label">UK Director</span>
+        <input type="date" id="date-UK Director" class="type-date" style="display:none;">
+      </label>
     </div>
 
     <button


### PR DESCRIPTION
## Summary
- Refresh color palette with neutral base and blue accent
- Replace sanction type checkboxes with toggle-style controls
- Improve instructions box contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f25c88d848332bb8a0cacdc6454cc