### PR TITLE
Fix preview pane overflow and button sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,12 +36,14 @@
       border: 1px solid var(--border);
       box-shadow: 0 2px 4px rgba(0,0,0,0.05);
       position: relative;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
       min-height: 20rem;
     }
     .step {
       display: grid;
       gap: 1.5rem;
+      justify-items: start;
       position: absolute;
       inset: 0;
       opacity: 0;


### PR DESCRIPTION
## Summary
- Enable vertical scrolling in the form so the preview and .docx download button remain visible
- Prevent buttons from stretching to full width within step panes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4719740483329cea0cf3a48065d6