### PR TITLE
Highlight sanction summary above checklist

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,26 @@
       --text: #212529;
       --primary-border: #b6d4fe;
     }
+    .sanction-summary {
+      margin: 1.5rem auto 1rem;
+      padding: 1.25rem 1.5rem;
+      background: #fff4d6;
+      color: #5c3d00;
+      border: 2px solid #f0b429;
+      border-radius: 0.75rem;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+      max-width: 45rem;
+    }
+    .sanction-summary__icon {
+      font-size: 1.75rem;
+    }
+    .sanction-summary strong {
+      font-weight: 700;
+    }
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background: var(--background);
@@ -383,9 +403,9 @@ document.getElementById('sanctionsForm').addEventListener('submit',e=>{
     if(types.length===2) return types.join(' and ');
     return `${types.slice(0,-1).join(', ')} and ${types[types.length-1]}`;
   };
-  const typeSummaryItem=selectedTypes.length
-    ? `<li><strong>${selectedTypes.length}</strong> sanction type${selectedTypes.length>1?'s':''} selected: ${formatTypeList(selectedTypes)}. Make sure MarComms is briefed on every update before distribution.</li>`
-    : `<li>No sanction types were selected. Confirm with Policy whether any updates are required before sending to MarComms.</li>`;
+  const sanctionSummary=selectedTypes.length
+    ? `<div class="sanction-summary" role="status"><span class="sanction-summary__icon" aria-hidden="true">⚠️</span><span><strong>${selectedTypes.length}</strong> sanction type${selectedTypes.length>1?'s':''} selected: ${formatTypeList(selectedTypes)}. Make sure MarComms is briefed on every update before distribution.</span></div>`
+    : `<div class="sanction-summary" role="status"><span class="sanction-summary__icon" aria-hidden="true">ℹ️</span><span>No sanction types were selected. Confirm with Policy whether any updates are required before sending to MarComms.</span></div>`;
 
   let out=`<p>[${statementDate}] - Instruction to update sanctions regime webpage(s) for ${regimeText} sanctions regime(s)</p>`;
 
@@ -413,13 +433,12 @@ document.getElementById('sanctionsForm').addEventListener('submit',e=>{
 
   const checklistItems=[
     `<li>Update the "Latest news" on a relevant sanctions webpage(s) with the following standard wording and links (do not change the links).</li>`,
-    typeSummaryItem,
     `<li>Set up the publication date as "Last updated" on the SharePoint tab. Please remove any "Latest news" notifications updates that have not occurred within the last 30 days, so not to clutter the website, always leaving the latest news item.</li>`,
     `<li>Manually embed the dates on the <a href="https://www.jerseyfsc.org/industry/international-co-operation/sanctions/sanctions-by-country-and-category/" target="_blank">Sanctions by country and category</a> table. Please note that the 'Latest news' date is the <strong>[DATE OF THE UK/UN AMENDMENT]</strong>, whilst the 'Last revised' date is the <strong>[DATE OF THE JFSC PUBLICATION]</strong>.</li>`,
     `<li>Please advise when you have updated the website and send the Policy staff member the links to check the wording.</li>`,
     `<li>Upon the Policy staff member's confirmation, please set up an e-mail alert for our subscribers and send it.</li>`
   ];
-  out+=`\n<hr>\n<ol>\n  ${checklistItems.join('\n  ')}\n</ol>`;
+  out+=`\n<hr>\n${sanctionSummary}\n<ol>\n  ${checklistItems.join('\n  ')}\n</ol>`;
 
   document.getElementById('output').innerHTML=out;
   document.getElementById('instructions').classList.add('show');


### PR DESCRIPTION
## Summary
- add a styled sanction summary callout so the selection message sits above the checklist
- keep the summary text dynamic while leaving the ordered checklist focused on actionable steps

## Testing
- Verified manually in the browser

------
https://chatgpt.com/codex/tasks/task_e_68cac3453d348332944831bada24e2af