### PR TITLE
Fix advice box updates (multi-class match + single-pass replacement)

### DIFF
--- a/Sanctions Tool Updater.html
+++ b/Sanctions Tool Updater.html
@@ -512,17 +512,18 @@
       });
 
       // Update advice boxes
-      adviceBoxes.forEach((adv, i) => {
-        const newHtml = markdownToHtml(adv.text);
-        let count = 0;
-        html = html.replace(
-          /(<div[^>]*class="step-instructions"[^>]*>)([\s\S]*?)(<\/div>)/gi,
-          (match, open, content, close) => {
-            if (count++ === i) return open + newHtml + close;
-            return match;
+      let count = 0;
+      html = html.replace(
+        /(<div[^>]*class="[^"]*step-instructions[^"]*"[^>]*>)([\s\S]*?)(<\/div>)/gi,
+        (match, open, content, close) => {
+          if (count < adviceBoxes.length) {
+            const newHtml = markdownToHtml(adviceBoxes[count].text);
+            count += 1;
+            return open + newHtml + close;
           }
-        );
-      });
+          return match;
+        }
+      );
 
       return html;
     }


### PR DESCRIPTION
### Motivation
- The previous replacement logic required `class="step-instructions"` exactly and therefore missed elements whose `class` attribute contained multiple classes like `class="instructions step-instructions"`.
- The code ran the global regex once per advice box which was wasteful and caused index misalignment when some matches were skipped.

### Description
- Relaxed the class match to `class="[^"]*step-instructions[^"]*"` so elements with multiple classes that include `step-instructions` are matched.
- Replaced the `adviceBoxes.forEach` multi-pass approach with a single `html.replace(..., callback)` pass that uses a `count` counter and calls `markdownToHtml(adviceBoxes[count].text)` inside the callback to insert replacements in order.
- Removed the per-box repeated regex executions and consolidated the logic in `Sanctions Tool Updater.html` to keep indices aligned and improve performance.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690a19484c83329fe8095afd4e837a)